### PR TITLE
upgrade SDK from 0.28.0 to 0.30.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-alpaca-py==0.28.0
+alpaca-py==0.30.1
 gemini_agents_toolkit==2.2.2
 python-dotenv==1.0.1
 python-telegram-bot==20.6


### PR DESCRIPTION
1. version conflict not found
2. the `time_in_force` is valid arg. I searched it in: local code, [GitHub repo](https://github.com/alpacahq/alpaca-py/tree/master?tab=readme-ov-file#trading-api-example-), [Documentation](https://alpaca.markets/sdks/python/trading.html#creating-an-order).

So, I have no idea what is `{"code":42210000,"message":"order_time_in_force provided not supported for options trading"}`.

Assumption: maybe this AI stuffed some fictional **order**__time_in_force_ argument into some function instead of a valid _time_in_force_ argument.